### PR TITLE
fix/os mapping

### DIFF
--- a/cloudwatch/osfamilymap.yaml
+++ b/cloudwatch/osfamilymap.yaml
@@ -1,6 +1,12 @@
 RedHat:
   pkg_ext: rpm
 
+Amazon:
+  pkg_ext: rpm
+
+CentOS:
+  pkg_ext: rpm
+
 Debian:
   pkg_ext: deb
 

--- a/cloudwatch/osfamilymap.yaml
+++ b/cloudwatch/osfamilymap.yaml
@@ -3,14 +3,6 @@ RedHat:
 
 Debian:
   pkg_ext: deb
-  config:
-    logs:
-      logs_collected:
-        files:
-          collect_list:
-            - log_stream_name: Packages
-              log_group_name: syslog
-              file_path: /var/log/dpkg.log
 
 Windows:
   package_name: Amazon CloudWatch Agent


### PR DESCRIPTION
CentOS and Amazon linux will return CentOS and Amazon respectively if you are querying grains['os'] but grains['os_family'] which we are mapping on, will give you 'RedHat'